### PR TITLE
Fix audio cuts w/ Unlock Read Speed

### DIFF
--- a/kernel/Patch.c
+++ b/kernel/Patch.c
@@ -4458,13 +4458,11 @@ void PatchGame()
 	DoPatches( (void*)DOLMinOff, FullLength, 0 );
 	// Some games need special timings
 	EXISetTimings(TITLE_ID, GAME_ID & 0xFF);
-        if(TRIGame != TRI_SB)
+	if(ConfigGetConfig(NIN_CFG_REMLIMIT))
         {
-	      if((TITLE_ID) != 0x474645)
-               {
-                 ISOSetupCache();
-                }
-        }
+		if((TITLE_ID) == 0x474146)
+			ISOSetupCache();
+	}
 	// Reset SI status
 	SIInit();
 	u32 SiInitSet = 0;


### PR DESCRIPTION
Taken from here:
https://github.com/FIX94/Nintendont/pull/552

Surprised MMMod never merged this, as it affects games like Melee, Air Ride, and Chibi-Robo

P.S. untested, as I could not get the source to build a .dol